### PR TITLE
Fixing mixed content errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,11 +50,10 @@ module.exports = {
       })
 
       // push to tags_map
-      var page_url = this.output.toURL(page.path);
       tags.forEach(function(e) {
         if (!tags_map[e]) tags_map[e] = [];
         tags_map[e].push({
-          url: page_url,
+          url: page.path,
           title: page.title
         });
       })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gitbook-plugin-tags",
     "description": "Add tags to GitBook",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "engines": {
         "gitbook": "*"
     },


### PR DESCRIPTION
Links are now of the form `a/b/c/` vs of the form `a/b/c`. Not having a trailing slash results in a mixed content error when clicking on the link.

<img width="1111" alt="mixed-content-error" src="https://user-images.githubusercontent.com/1643937/34193803-8d2379b6-e50a-11e7-95b9-8fb406f9429d.png">
